### PR TITLE
chore: update stellar-sdk to v13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@simplewebauthn/browser": "^11.0.0",
-    "@stellar/stellar-sdk": "13.0.0-beta.1",
+    "@stellar/stellar-sdk": "13.0.0-rc.1",
     "base64url": "^3.0.1",
     "buffer": "^6.0.3",
     "passkey-factory-sdk": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@simplewebauthn/browser": "^11.0.0",
-    "@stellar/stellar-sdk": "13.0.0-rc.1",
+    "@stellar/stellar-sdk": "^13.0.0",
     "base64url": "^3.0.1",
     "buffer": "^6.0.3",
     "passkey-factory-sdk": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@stellar/stellar-sdk': 13.0.0-beta.1
+  '@stellar/stellar-sdk': 13.0.0-rc.1
 
 importers:
 
@@ -15,8 +15,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-beta.1
-        version: 13.0.0-beta.1
+        specifier: 13.0.0-rc.1
+        version: 13.0.0-rc.1
       base64url:
         specifier: ^3.0.1
         version: 3.0.1
@@ -46,8 +46,8 @@ importers:
   packages/passkey-factory-sdk:
     dependencies:
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-beta.1
-        version: 13.0.0-beta.1
+        specifier: 13.0.0-rc.1
+        version: 13.0.0-rc.1
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -59,8 +59,8 @@ importers:
   packages/passkey-kit-sdk:
     dependencies:
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-beta.1
-        version: 13.0.0-beta.1
+        specifier: 13.0.0-rc.1
+        version: 13.0.0-rc.1
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -72,8 +72,8 @@ importers:
   packages/sac-sdk:
     dependencies:
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-beta.1
-        version: 13.0.0-beta.1
+        specifier: 13.0.0-rc.1
+        version: 13.0.0-rc.1
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -93,11 +93,11 @@ packages:
   '@stellar/js-xdr@3.1.2':
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
 
-  '@stellar/stellar-base@13.0.0-beta.1':
-    resolution: {integrity: sha512-S5c2FyKwUOc28/3sDoOfPIcdzcbUyfiYRmcUlscZrEX/VVzV12216XRkdWy2MYa8KQNK60MpR7wrGp2MamvVGg==}
+  '@stellar/stellar-base@13.0.0':
+    resolution: {integrity: sha512-zS/F1P2MfvgoIlUxOM3PMAEm76qoP5N7HYiww6y6EMP+j3brVFTnTIlJuYdnRdVaPXC/Z4BpojG3bVyhs32Tiw==}
 
-  '@stellar/stellar-sdk@13.0.0-beta.1':
-    resolution: {integrity: sha512-yJN2HzibhZFJsdLRU83bkUwb9dq1sZRRiQptTJyunVv0hQsF+tTldrP3hHst3LROv/2GWTn20tmAqnp0hkzOhg==}
+  '@stellar/stellar-sdk@13.0.0-rc.1':
+    resolution: {integrity: sha512-a173pQPCuS8/xVET/euwp8UWEFsE68KGF21Xcq46TluDGIq0fKVmJ6mw1LAS2uEOE757rrY24KNGAux4FXR64g==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -188,8 +188,8 @@ packages:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
     hasBin: true
 
-  sodium-native@4.2.1:
-    resolution: {integrity: sha512-48X3PfRLW+f0fgb3J7f7mkZ9eBKcGR/bD5mdXXLAx4RWwKUe3095yPQgiUUQTfh8Q29JzwhSQATitQDBIozN/w==}
+  sodium-native@4.3.0:
+    resolution: {integrity: sha512-OcMgoS0NJx+4yVUlhvL9uZsVZfmyHZ2RpSXkiIoOHMglqvJDeGwn1rUigPrvcNTq3m9hPXtt6syxQbF3vvwmRQ==}
 
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
@@ -223,7 +223,7 @@ snapshots:
 
   '@stellar/js-xdr@3.1.2': {}
 
-  '@stellar/stellar-base@13.0.0-beta.1':
+  '@stellar/stellar-base@13.0.0':
     dependencies:
       '@stellar/js-xdr': 3.1.2
       base32.js: 0.1.0
@@ -232,11 +232,11 @@ snapshots:
       sha.js: 2.4.11
       tweetnacl: 1.0.3
     optionalDependencies:
-      sodium-native: 4.2.1
+      sodium-native: 4.3.0
 
-  '@stellar/stellar-sdk@13.0.0-beta.1':
+  '@stellar/stellar-sdk@13.0.0-rc.1':
     dependencies:
-      '@stellar/stellar-base': 13.0.0-beta.1
+      '@stellar/stellar-base': 13.0.0
       axios: 1.7.7
       bignumber.js: 9.1.2
       eventsource: 2.0.2
@@ -322,7 +322,7 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
-  sodium-native@4.2.1:
+  sodium-native@4.3.0:
     dependencies:
       node-gyp-build: 4.8.2
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@stellar/stellar-sdk': 13.0.0-rc.1
+  '@stellar/stellar-sdk': ^13.0.0
 
 importers:
 
@@ -15,8 +15,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-rc.1
-        version: 13.0.0-rc.1
+        specifier: ^13.0.0
+        version: 13.0.0
       base64url:
         specifier: ^3.0.1
         version: 3.0.1
@@ -46,8 +46,8 @@ importers:
   packages/passkey-factory-sdk:
     dependencies:
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-rc.1
-        version: 13.0.0-rc.1
+        specifier: ^13.0.0
+        version: 13.0.0
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -59,8 +59,8 @@ importers:
   packages/passkey-kit-sdk:
     dependencies:
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-rc.1
-        version: 13.0.0-rc.1
+        specifier: ^13.0.0
+        version: 13.0.0
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -72,8 +72,8 @@ importers:
   packages/sac-sdk:
     dependencies:
       '@stellar/stellar-sdk':
-        specifier: 13.0.0-rc.1
-        version: 13.0.0-rc.1
+        specifier: ^13.0.0
+        version: 13.0.0
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -93,11 +93,11 @@ packages:
   '@stellar/js-xdr@3.1.2':
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
 
-  '@stellar/stellar-base@13.0.0':
-    resolution: {integrity: sha512-zS/F1P2MfvgoIlUxOM3PMAEm76qoP5N7HYiww6y6EMP+j3brVFTnTIlJuYdnRdVaPXC/Z4BpojG3bVyhs32Tiw==}
+  '@stellar/stellar-base@13.0.1':
+    resolution: {integrity: sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==}
 
-  '@stellar/stellar-sdk@13.0.0-rc.1':
-    resolution: {integrity: sha512-a173pQPCuS8/xVET/euwp8UWEFsE68KGF21Xcq46TluDGIq0fKVmJ6mw1LAS2uEOE757rrY24KNGAux4FXR64g==}
+  '@stellar/stellar-sdk@13.0.0':
+    resolution: {integrity: sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -223,7 +223,7 @@ snapshots:
 
   '@stellar/js-xdr@3.1.2': {}
 
-  '@stellar/stellar-base@13.0.0':
+  '@stellar/stellar-base@13.0.1':
     dependencies:
       '@stellar/js-xdr': 3.1.2
       base32.js: 0.1.0
@@ -234,9 +234,9 @@ snapshots:
     optionalDependencies:
       sodium-native: 4.3.0
 
-  '@stellar/stellar-sdk@13.0.0-rc.1':
+  '@stellar/stellar-sdk@13.0.0':
     dependencies:
-      '@stellar/stellar-base': 13.0.0
+      '@stellar/stellar-base': 13.0.1
       axios: 1.7.7
       bignumber.js: 9.1.2
       eventsource: 2.0.2

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from "@stellar/stellar-sdk/minimal"
+import { rpc } from "@stellar/stellar-sdk/minimal"
 
 // TODO consider adding support for a signAuthEntry method that conforms to the ed25519 signature scheme of this passkey interface
 // once we do that we can clean the code a little with the `xdr.HashIdPreimage.envelopeTypeSorobanAuthorization` stuff
@@ -7,12 +7,12 @@ import { SorobanRpc } from "@stellar/stellar-sdk/minimal"
 
 export class PasskeyBase {
     public rpcUrl: string | undefined
-    public rpc: SorobanRpc.Server | undefined
-    
+    public rpc: rpc.Server | undefined
+
     constructor(rpcUrl?: string) {
         if (rpcUrl) {
             this.rpcUrl = rpcUrl
-            this.rpc = new SorobanRpc.Server(rpcUrl)
+            this.rpc = new rpc.Server(rpcUrl)
         }
     }
 }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1,6 +1,6 @@
 import { Client as FactoryClient } from 'passkey-factory-sdk'
 import { Client as PasskeyClient, type Signature, type SignerKey as SDKSignerKey, type SignerLimits as SDKSignerLimits } from 'passkey-kit-sdk'
-import { StrKey, hash, xdr, SorobanRpc, Keypair, Address } from '@stellar/stellar-sdk/minimal'
+import { StrKey, hash, xdr, rpc, Keypair, Address } from '@stellar/stellar-sdk/minimal'
 import type { AuthenticatorAttestationResponseJSON, AuthenticatorSelectionCriteria } from "@simplewebauthn/types"
 import { startRegistration, startAuthentication } from "@simplewebauthn/browser"
 import { Buffer } from 'buffer'
@@ -12,7 +12,7 @@ import { AssembledTransaction, DEFAULT_TIMEOUT, type Tx, type Spec } from '@stel
 // TODO Return base64url encoded strings as well as buffers
 
 export class PasskeyKit extends PasskeyBase {
-    declare public rpc: SorobanRpc.Server
+    declare public rpc: rpc.Server
     declare public rpcUrl: string
     public keyId: string | undefined
     public networkPassphrase: string
@@ -475,7 +475,7 @@ export class PasskeyKit extends PasskeyBase {
         });
     }
 
-    /* LATER 
+    /* LATER
         - Add a getKeyInfo action to get info about a specific passkey
             Specifically looking for name, type, etc. data so a user could grok what signer mapped to what passkey
     */

--- a/src/sac.ts
+++ b/src/sac.ts
@@ -1,12 +1,12 @@
 import { Client as SacClient } from 'sac-sdk'
 import { PasskeyBase } from "./base"
-import type { SorobanRpc } from '@stellar/stellar-sdk/minimal'
+import type { rpc } from '@stellar/stellar-sdk/minimal'
 
 export class SACClient extends PasskeyBase {
-    declare public rpc: SorobanRpc.Server
+    declare public rpc: rpc.Server
     declare public rpcUrl: string
     public networkPassphrase: string
-    
+
     constructor(options: {
         networkPassphrase: string,
         rpcUrl: string

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, Transaction, xdr } from "@stellar/stellar-sdk/minimal"
+import { rpc, Transaction, xdr } from "@stellar/stellar-sdk/minimal"
 import { PasskeyBase } from "./base"
 import base64url from "base64url"
 import type { Tx } from "@stellar/stellar-sdk/minimal/contract"
@@ -85,7 +85,7 @@ export class PasskeyServer extends PasskeyBase {
         for (const signer of signers) {
             if (signer.storage === 'Temporary') {
                 try {
-                    await this.rpc.getContractData(contractId, xdr.ScVal.scvBytes(base64url.toBuffer(signer.key)), SorobanRpc.Durability.Temporary)
+                    await this.rpc.getContractData(contractId, xdr.ScVal.scvBytes(base64url.toBuffer(signer.key)), rpc.Durability.Temporary)
                 } catch {
                     signer.evicted = true
                 }


### PR DESCRIPTION
In RC1 the `SorobanRpc` export has been removed, and `rpc` should be used instead.

Refs: https://github.com/stellar/js-stellar-sdk/releases/tag/v13.0.0-rc.1