### PR TITLE
Add require_auth() check to update_signer function

### DIFF
--- a/contracts/smart-wallet/src/lib.rs
+++ b/contracts/smart-wallet/src/lib.rs
@@ -64,10 +64,10 @@ impl SmartWalletInterface for Contract {
         );
     }
     fn update_signer(env: Env, signer: Signer) {
+        env.current_contract_address().require_auth();
+
         let (signer_key, signer_val, signer_storage) = process_signer(signer);
-
         store_signer(&env, &signer_key, &signer_val, &signer_storage, true);
-
         extend_instance(&env);
 
         env.events().publish(


### PR DESCRIPTION
Adds missing auth check to prevent unauthorized modifications to existing signers

Fix to #21 